### PR TITLE
Update for JupyterLab 0.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "mimeExtension": true
   },
   "dependencies": {
-    "@jupyterlab/application": "^0.10.0",
-    "@jupyterlab/rendermime-interfaces": "^0.3.0",
+    "@jupyterlab/rendermime-interfaces": "^0.4.0",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/widgets": "^1.5.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,13 +114,13 @@ const execRendererFactory: IRenderMime.IRendererFactory = {
 
 const extensions: IRenderMime.IExtension[] = [
   {
-    name: 'bokeh_load',
+    id: 'jupyterlab_bokeh:load',
     rendererFactory: loadRendererFactory,
     rank: 0,
     dataType: 'json' // {"script": script, "div": div}
   },
   {
-    name: 'bokeh_exec',
+    id: 'jupyterlab_bokeh:exec',
     rendererFactory: execRendererFactory,
     rank: 0,
     dataType: 'json' // {"script": script, "div": div}


### PR DESCRIPTION
Tested locally with JupyterLab 0.28 and the following code:


```python
from bokeh.io import output_notebook, show
from bokeh.plotting import figure

output_notebook()

# create a new plot with default tools, using figure
p = figure(plot_width=400, plot_height=400)

# add a circle renderer with a size, color, and alpha
p.circle([1, 2, 3, 4, 5], [6, 7, 2, 4, 5], size=15, line_color="navy", fill_color="orange", fill_alpha=0.5)

show(p) # show the results
```