### PR TITLE
Standardize package extension keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "keywords": [
     "jupyter",
     "jupyterlab",
-    "jupyterlab extension",
+    "jupyterlab-extension",
     "bokeh",
     "bokehjs"
   ],


### PR DESCRIPTION
See https://github.com/jupyterlab/jupyterlab/issues/3841 for a discussion about standardizing extension keywords for eased use and discoverability.