### PR TITLE
Updating typescript to fix build issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   },
   "devDependencies": {
     "rimraf": "^2.6.1",
-    "typescript": "~2.4.0"
+    "typescript": "~2.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@phosphor/widgets": "^1.5.0"
   },
   "devDependencies": {
-    "rimraf": "^2.6.1",
+    "rimraf": "^2.6.2",
     "typescript": "~2.6.2"
   }
 }


### PR DESCRIPTION
Currently getting the following when running npm run build:

`
> tsc

node_modules/@types/react/index.d.ts(3507,58): error TS2304: Cannot find name 'HTMLDialogElement'.
node_modules/@types/react/index.d.ts(3507,78): error TS2304: Cannot find name 'HTMLDialogElement'.
node_modules/@types/react/index.d.ts(3781,72): error TS2304: Cannot find name 'HTMLDialogElement'.
node_modules/@types/react/index.d.ts(3781,92): error TS2304: Cannot find name 'HTMLDialogElement'.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! jupyterlab_bokeh@0.3.0 build: `tsc`
npm ERR! Exit status 1
`

This pull request updates the typescript/rimraf versions to match that in jupyterlab, and to be built properly. 