### PR TITLE
Bump release version to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab_bokeh",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "A JupyterLab extension for rendering Bokeh content",
   "author": "Luke Canavan <lcanavan@anaconda.org>",
   "main": "lib/index.js",


### PR DESCRIPTION
Bump release version to 0.4.0

When https://github.com/bokeh/bokeh/pull/7567 is merged, I'll merge this and publish the release.