### PR TITLE
Work around bad design of eslint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 script:
 - npm install
 - npm run build
-#- npm run lint
+- PARSER_NO_WATCH=true npm run lint
 - jupyter labextension install .
 - jupyter lab clean
 - jupyter labextension link .


### PR DESCRIPTION
Apparently linting a few files requires watching entire file system for changes, causing exhaustion of system watchers, especially on travis ci, where the limit is pretty low.